### PR TITLE
Replies should have the aa (Authoritative) flag set to true

### DIFF
--- a/cmd/server/chaserv.go
+++ b/cmd/server/chaserv.go
@@ -199,6 +199,7 @@ func parseQuery(m *dns.Msg) {
 
 			rr, _ := dns.NewRR(fmt.Sprintf("%s TXT %s", q.Name, answer))
 			m.Answer = append(m.Answer, rr)
+			m.MsgHdr.Authoritative = true
 
 		}
 


### PR DESCRIPTION

```
chashell 300 IN A [SERVERIP]
c 300 IN NS chashell.[DOMAIN].
```

The chanserv running at [SERVERIP] is an authoritative nameserver for chashell.[DOMAIN]. 

The message header reply should therefore have the 'aa' (Authoritative) flag set. 

Without this flag, a strict recursive nameserver may block replies from reaching the client